### PR TITLE
Untitled

### DIFF
--- a/src/network_utils.cpp
+++ b/src/network_utils.cpp
@@ -78,7 +78,7 @@ namespace NetworkUtils {
     }
 
     // Fetch the HTML content of a web page with retry mechanism
-    std::string fetchPageWithRetry(const std::string& url, int maxRetries = 3, int retryDelay = 2000) {
+    std::string fetchPageWithRetry(const std::string& url, int maxRetries, int retryDelay) {
         int attempt = 0;
         while (attempt < maxRetries) {
             try {


### PR DESCRIPTION
Remove the default arguments from the function definition of `fetchPageWithRetry`.

* Change the function definition of `fetchPageWithRetry` to remove default arguments for `maxRetries` and `retryDelay`.
